### PR TITLE
feat: Disabling customer name when fetching data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=8.2",
         "doctrine/orm": "^3.2",
-        "novosga/core": "self.version",
+        "novosga/core": "2.2.x-dev",
         "symfony/framework-bundle": "7.1.*",
         "psr/clock": "^1.0"
     },

--- a/src/Resources/public/js/script.js
+++ b/src/Resources/public/js/script.js
@@ -30,6 +30,7 @@
             prioridades: (prioridades || []),
             unidade: (unidade || {}),
             cliente: {
+                id: null,
                 nome: '',
                 documento: ''
             },
@@ -47,6 +48,7 @@
                 exibir: true,
                 desabilitados: [],
             },
+            fetchingClientes: false,
             clientes: [],
             agendamentos: [],
             servicoAgendamento: null,
@@ -188,7 +190,10 @@
                         cliente: null,
                     };
                     if (this.cliente.nome && this.cliente.documento) {
-                        data.cliente = {...this.cliente};
+                        data.cliente = {
+                            nome: this.cliente.nome,
+                            documento: this.cliente.documento,
+                        };
                     }
 
                     App.ajax({
@@ -268,24 +273,36 @@
                 });
             },
             fetchClients: _.debounce(function () {
+                this.fetchingClientes = true;
                 App.ajax({
                     url: App.url('/novosga.triage/clientes'),
                     data: {
                         q: this.cliente.documento
                     },
                     success: (response) => {
+                        this.fetchingClientes = false;
                         this.clientes = response.data;
+                        this.changeClient();
+                    },
+                    error: () => {
+                        this.fetchingClientes = false;
                     }
                 })
-            }, 250),
+            }, 400),
+            changeDocumento() {
+                this.cliente.documento = this.cliente.documento.toUpperCase();
+                this.fetchClients();
+            },
             changeClient() {
-                this.cliente.nome = '';
-                for (var i in this.clientes) {
-                    var c = this.clientes[i];
-                    if (c.documento === this.cliente.documento) {
-                        this.cliente.nome = c.nome;
-                        break;
-                    }
+                const isDisabled = this.cliente.id;
+                this.cliente.id = null;
+                const existingCliente = this.clientes.find((c) => c.documento === this.cliente.documento)
+                if (existingCliente) {
+                    this.cliente.id = existingCliente.id;
+                    this.cliente.nome = existingCliente.nome;
+                    this.cliente.documento = existingCliente.documento;
+                } else if (isDisabled) {
+                    this.cliente.nome = '';
                 }
             }
         },

--- a/src/Resources/views/default/index.html.twig
+++ b/src/Resources/views/default/index.html.twig
@@ -37,7 +37,7 @@
                             </span>
                             <label for="cliente-documento" class="sr-only">{{ 'label.customer.id'|trans }}</label>
                             <input type="text" id="cliente-documento" list="documentos" class="form-control" maxlength="30" placeholder="{{ 'label.customer.id'|trans }}" v-model="cliente.documento" 
-                                   v-on:input="fetchClients"
+                                   v-on:input="changeDocumento"
                                    v-on:change="changeClient"
                                    v-on:blur="changeClient">
                             <datalist id="documentos">
@@ -51,7 +51,7 @@
                                 <i class="fa fa-user"></i>
                             </span>
                             <label for="cliente-nome" class="sr-only">{{ 'label.name'|trans }}</label>
-                            <input type="text" id="cliente-nome" class="form-control" maxlength="100" placeholder="{{ 'label.name'|trans }}" v-model="cliente.nome" />
+                            <input type="text" id="cliente-nome" class="form-control" maxlength="100" placeholder="{{ 'label.name'|trans }}" v-model="cliente.nome" :disabled="fetchingClientes || cliente.id" />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Além de desabilitar o campo de nome enquanto estiver buscando por clientes, o campo também ficará desabilitado quando um cliente já existir (id !== null).

Isso evita a confusão quando utilizando um documento já cadastrado mas alterando o nome do cliente. O que resulta no uso do cliente que já estava cadastrado anteriormente (outro nome).