### PR TITLE
fix: creating ticket for single priority

### DIFF
--- a/src/Resources/public/js/script.js
+++ b/src/Resources/public/js/script.js
@@ -119,9 +119,9 @@
                 });
             },
             showPrioridades(servicoId) {
-                if (this.prioridades.length === 1) {
+                if (this.demaisPrioridades.length === 1) {
                     // se so tiver uma prioridade, emite a senha direto
-                    this.distribuiSenha(servicoId, this.prioridades[0].id);
+                    this.distribuiSenha(servicoId, this.demaisPrioridades[0].id);
                 } else {
                     this.servico = servicoId;
                     this.prioridadeModal.show();


### PR DESCRIPTION
Avoid to open the priority chooser modal when there is only one priority (peso > 0).