### PR TITLE
fix: use unit timezone when parsing scheduled appointment datetime

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -236,7 +236,7 @@ class DefaultController extends AbstractController
 
         $data = $agendamento->getData()->format('Y-m-d');
         $hora = $agendamento->getHora()->format('H:i');
-        $dt = DateTime::createFromFormat('Y-m-d H:i', "{$data} {$hora}");
+        $dt = DateTime::createFromFormat('Y-m-d H:i', "{$data} {$hora}", $agendamento->getUnidade()->getDateTimeZone());
         $now = $clock->now();
 
         if ($dt < $now) {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -310,7 +310,7 @@ class DefaultController extends AbstractController
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
-        $data = $clock->now();
+        $data = $clock->now()->setTimezone($unidade->getDateTimeZone());
 
         $agendamentos = $agendamentoRepository->findByUnidadeAndServicoAndData(
             $unidade,

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -234,10 +234,11 @@ class DefaultController extends AbstractController
             throw new Exception($translator->trans('error.schedule.confirmed', [], NovosgaTriageBundle::getDomain()));
         }
 
+        $timezone = $agendamento->getUnidade()->getDateTimeZone();
         $data = $agendamento->getData()->format('Y-m-d');
         $hora = $agendamento->getHora()->format('H:i');
-        $dt = DateTime::createFromFormat('Y-m-d H:i', "{$data} {$hora}", $agendamento->getUnidade()->getDateTimeZone());
-        $now = $clock->now();
+        $dt = DateTime::createFromFormat('Y-m-d H:i', "{$data} {$hora}", $timezone);
+        $now = $clock->now()->setTimezone($timezone);
 
         if ($dt < $now) {
             $diff = $now->diff($dt);


### PR DESCRIPTION
Issue: https://github.com/novosga/novosga/issues/454

Related to https://github.com/novosga/novosga/pull/492

## Summary

- Fix `DateTime::createFromFormat` call that ignored the unit's configured timezone when building a `DateTime` from a scheduled appointment's date+time strings
- Without this fix, appointments in units with a non-default timezone could be incorrectly flagged as expired at triage

## Test plan

- [x] Confirm a scheduled appointment in a unit with a non-UTC timezone
- [x] Verify the appointment is not incorrectly rejected as expired at triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)