### PR TITLE
chore: upgrade Symfony from 7.1 to 7.4 LTS (#455)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,20 @@
     "license": "MIT",
     "type": "symfony-bundle",
     "autoload": {
-        "psr-4": { "Novosga\\TriageBundle\\": "src/" }
+        "psr-4": {
+            "Novosga\\TriageBundle\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Novosga\\TriageBundle\\Tests\\": "tests/" }
+        "psr-4": {
+            "Novosga\\TriageBundle\\Tests\\": "tests/"
+        }
     },
     "require": {
         "php": ">=8.2",
         "doctrine/orm": "^3.2",
         "novosga/core": "2.3.x-dev",
-        "symfony/framework-bundle": "7.1.*",
+        "symfony/framework-bundle": "7.4.*",
         "psr/clock": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

Part of novosga/novosga#455 — main PR: novosga/novosga#495.

Bumps all `symfony/*` constraints from `7.1.*` → `7.4.*` in `composer.json`.

## Test plan

- [x] `composer install` resolves cleanly
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)