### PR TITLE
chore: upgrade dev tools (phpstan 2, phpunit 11, phpcs 4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,11 @@
         "psr/clock": "^1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5",
-        "slevomat/coding-standard": "~8.0"
+        "phpstan/phpdoc-parser": "^2.3.2",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^11.5.55",
+        "slevomat/coding-standard": "^8.28",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,6 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         convertDeprecationsToExceptions="false"
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -20,11 +19,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 
     <extensions>
     </extensions>


### PR DESCRIPTION
Upgrade dev-only dependencies to match the versions used in the main application (novosga/novosga#455):

- `phpstan/phpstan`: `^1.10` → `^2.1`
- `phpstan/phpdoc-parser`: added `^2.3.2`
- `phpunit/phpunit`: `^9.5` → `^11.5.55`
- `slevomat/coding-standard`: `~8.0` → `^8.28`
- `squizlabs/php_codesniffer`: added `^4.0`

Fix PHPStan 2 issues (use `assert()` for type narrowing of `getUser()` calls) and update `phpunit.xml.dist` for PHPUnit 11 compatibility.