### PR TITLE
feat: Appointment max delay config

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Novosga\TriageBundle\Controller;
 
-use DateTime;
 use Exception;
 use Novosga\Entity\UsuarioInterface;
 use Novosga\Http\Envelope;
@@ -45,8 +44,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Route("/", name: "novosga_triage_")]
 class DefaultController extends AbstractController
 {
-    private const MAX_SCHEDULING_MINUTES_DELAY = 60;
-
     #[Route("/", name: "index", methods: ['GET'])]
     public function index(
         ServicoServiceInterface $servicoService,
@@ -223,7 +220,6 @@ class DefaultController extends AbstractController
         AgendamentoServiceInterface $agendamentoService,
         PrioridadeRepositoryInterface $prioridadeRepository,
         TranslatorInterface $translator,
-        ClockInterface $clock,
         int $id,
     ): Response {
         $agendamento = $agendamentoService->getById($id);
@@ -232,24 +228,6 @@ class DefaultController extends AbstractController
         }
         if ($agendamento->getDataConfirmacao()) {
             throw new Exception($translator->trans('error.schedule.confirmed', [], NovosgaTriageBundle::getDomain()));
-        }
-
-        $timezone = $agendamento->getUnidade()->getDateTimeZone();
-        $data = $agendamento->getData()->format('Y-m-d');
-        $hora = $agendamento->getHora()->format('H:i');
-        $dt = DateTime::createFromFormat('Y-m-d H:i', "{$data} {$hora}", $timezone);
-        $now = $clock->now()->setTimezone($timezone);
-
-        if ($dt < $now) {
-            $diff = $now->diff($dt);
-            $mins = $diff->i + ($diff->h * 60);
-            if ($mins > self::MAX_SCHEDULING_MINUTES_DELAY) {
-                throw new Exception($translator->trans(
-                    'error.schedule.expired',
-                    [ '%min%' => self::MAX_SCHEDULING_MINUTES_DELAY ],
-                    NovosgaTriageBundle::getDomain()
-                ));
-            }
         }
 
         /** @var UsuarioInterface */

--- a/src/Resources/translations/NovosgaTriageBundle.en.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.en.xlf
@@ -14,239 +14,235 @@
       <trans-unit id="1">
         <source>title</source>
         <target>Screening</target>
-        
+
       </trans-unit>
       <trans-unit id="2">
         <source>subtitle</source>
         <target>Tickets issue</target>
-        
+
       </trans-unit>
       <trans-unit id="3">
         <source>button.find</source>
         <target>Search</target>
-        
+
       </trans-unit>
       <trans-unit id="4">
         <source>placeholder.search</source>
         <target>Ticket search</target>
-        
+
       </trans-unit>
       <trans-unit id="5">
         <source>label.no_priority</source>
         <target>Normal</target>
-        
+
       </trans-unit>
       <trans-unit id="6">
         <source>label.priority</source>
         <target>Priority</target>
-        
+
       </trans-unit>
       <trans-unit id="7">
         <source>label.total</source>
         <target>Total</target>
-        
+
       </trans-unit>
       <trans-unit id="8">
         <source>modal.attendance</source>
         <target>Attending</target>
-        
+
       </trans-unit>
       <trans-unit id="9">
         <source>modal.attendance.ticket</source>
         <target>Ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="10">
         <source>label.service</source>
         <target>Service</target>
-        
+
       </trans-unit>
       <trans-unit id="11">
         <source>label.ticket.wait_time</source>
         <target>Waiting time</target>
-        
+
       </trans-unit>
       <trans-unit id="12">
         <source>label.customer</source>
         <target>Customer</target>
-        
+
       </trans-unit>
       <trans-unit id="13">
         <source>label.customer.name</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="14">
         <source>label.customer.id</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="15">
         <source>label.yes</source>
         <target>Yes</target>
-        
+
       </trans-unit>
       <trans-unit id="16">
         <source>label.no</source>
         <target>No</target>
-        
+
       </trans-unit>
       <trans-unit id="17">
         <source>alert.title</source>
         <target>Alert</target>
-        
+
       </trans-unit>
       <trans-unit id="18">
         <source>alert.cancel.text</source>
         <target>Do you really wish to cancel that ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="19">
         <source>alert.reactivate.text</source>
         <target>Do you really wish to reactivate that ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="20">
         <source>alert.transfer.text</source>
         <target>Do you really want to transfer this ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="21">
         <source>modal.attendance.button.reactivate</source>
         <target>Reactivate ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="22">
         <source>modal.attendance.button.transfer</source>
         <target>Transfer / change ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="23">
         <source>modal.attendance.button.cancel</source>
         <target>Cancel ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="24">
         <source>modal.transfer</source>
         <target>Transfer ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="25">
         <source>modal.transfer.button</source>
         <target>Transfer</target>
-        
+
       </trans-unit>
       <trans-unit id="35">
         <source>modal.search</source>
         <target>Search</target>
-        
+
       </trans-unit>
       <trans-unit id="36">
         <source>modal.search.placeholder</source>
         <target>Full ticket code,  chars or number</target>
-        
+
       </trans-unit>
       <trans-unit id="37">
         <source>label.ticket.number</source>
         <target>Number</target>
-        
+
       </trans-unit>
       <trans-unit id="38">
         <source>label.ticket.arrival_date</source>
         <target>Date of arrival</target>
-        
+
       </trans-unit>
       <trans-unit id="39">
         <source>label.ticket.start_date</source>
         <target>Start date</target>
-        
+
       </trans-unit>
       <trans-unit id="40">
         <source>label.ticket.end_date</source>
         <target>End date</target>
-        
+
       </trans-unit>
       <trans-unit id="41">
         <source>label.triage</source>
         <target>Screening</target>
-        
+
       </trans-unit>
       <trans-unit id="42">
         <source>label.ticket.user</source>
         <target>Attendant</target>
-        
+
       </trans-unit>
       <trans-unit id="43">
         <source>label.status</source>
         <target>Status</target>
-        
+
       </trans-unit>
       <trans-unit id="44">
         <source>MM/DD/YYYY HH:mm:ss</source>
         <target>MM/DD/YYYY HH:mm:ss</target>
-        
+
       </trans-unit>
       <trans-unit id="45">
         <source>MM/DD/YYYY</source>
-        
+
       </trans-unit>
       <trans-unit id="49">
         <source>modal.search.button.submit</source>
         <target>Search</target>
-        
+
       </trans-unit>
       <trans-unit id="50">
         <source>server.datetime</source>
         <target>Server datetime</target>
-        
+
       </trans-unit>
       <trans-unit id="51">
         <source>error.invalid_service</source>
         <target>Invalid service</target>
-        
+
       </trans-unit>
       <trans-unit id="52">
         <source>error.schedule.confirmed</source>
-        
-      </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        
+
       </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="55">
         <source>label.priority</source>
         <target>Priority</target>
-        
+
       </trans-unit>
       <trans-unit id="56">
         <source>label.ticket</source>
         <target>Ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="57">
         <source>label.customer.id</source>
         <target>Document</target>
-        
+
       </trans-unit>
       <trans-unit id="58">
         <source>label.description</source>
         <target>Description</target>
-        
+
       </trans-unit>
       <trans-unit id="59">
         <source>label.subservices</source>
         <target>Subservices </target>
-        
+
       </trans-unit>
       <trans-unit id="60">
         <source>label.date</source>
         <target>Date</target>
-        
+
       </trans-unit>
       <trans-unit id="61">
         <source>label.time</source>

--- a/src/Resources/translations/NovosgaTriageBundle.en_US.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.en_US.xlf
@@ -14,239 +14,235 @@
       <trans-unit id="1">
         <source>title</source>
         <target>Screening</target>
-        
+
       </trans-unit>
       <trans-unit id="2">
         <source>subtitle</source>
         <target>Ticket issue</target>
-        
+
       </trans-unit>
       <trans-unit id="3">
         <source>button.find</source>
         <target>Search</target>
-        
+
       </trans-unit>
       <trans-unit id="4">
         <source>placeholder.search</source>
         <target>Ticket search</target>
-        
+
       </trans-unit>
       <trans-unit id="5">
         <source>label.no_priority</source>
         <target>Normal</target>
-        
+
       </trans-unit>
       <trans-unit id="6">
         <source>label.priority</source>
         <target>Priority</target>
-        
+
       </trans-unit>
       <trans-unit id="7">
         <source>label.total</source>
         <target>Total</target>
-        
+
       </trans-unit>
       <trans-unit id="8">
         <source>modal.attendance</source>
         <target>Attendance</target>
-        
+
       </trans-unit>
       <trans-unit id="9">
         <source>modal.attendance.ticket</source>
         <target>Ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="10">
         <source>label.service</source>
         <target>Service</target>
-        
+
       </trans-unit>
       <trans-unit id="11">
         <source>label.ticket.wait_time</source>
         <target>Waiting time</target>
-        
+
       </trans-unit>
       <trans-unit id="12">
         <source>label.customer</source>
         <target>Customer </target>
-        
+
       </trans-unit>
       <trans-unit id="13">
         <source>label.customer.name</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="14">
         <source>label.customer.id</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="15">
         <source>label.yes</source>
         <target>Yes</target>
-        
+
       </trans-unit>
       <trans-unit id="16">
         <source>label.no</source>
         <target>No</target>
-        
+
       </trans-unit>
       <trans-unit id="17">
         <source>alert.title</source>
         <target>Attention!</target>
-        
+
       </trans-unit>
       <trans-unit id="18">
         <source>alert.cancel.text</source>
         <target>Do you really want to cancel this ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="19">
         <source>alert.reactivate.text</source>
         <target>Do you really want to reactivate this ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="20">
         <source>alert.transfer.text</source>
         <target>Do you really want to transfer this ticket?</target>
-        
+
       </trans-unit>
       <trans-unit id="21">
         <source>modal.attendance.button.reactivate</source>
         <target>Re-enable ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="22">
         <source>modal.attendance.button.transfer</source>
         <target>Transfer / Change ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="23">
         <source>modal.attendance.button.cancel</source>
         <target>Cancel ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="24">
         <source>modal.transfer</source>
         <target>Transfer ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="25">
         <source>modal.transfer.button</source>
         <target>Download</target>
-        
+
       </trans-unit>
       <trans-unit id="35">
         <source>modal.search</source>
         <target>Find</target>
-        
+
       </trans-unit>
       <trans-unit id="36">
         <source>modal.search.placeholder</source>
         <target>Complete ticket, letters or number</target>
-        
+
       </trans-unit>
       <trans-unit id="37">
         <source>label.ticket.number</source>
         <target>Number</target>
-        
+
       </trans-unit>
       <trans-unit id="38">
         <source>label.ticket.arrival_date</source>
         <target>Arrival date</target>
-        
+
       </trans-unit>
       <trans-unit id="39">
         <source>label.ticket.start_date</source>
         <target>Initial date</target>
-        
+
       </trans-unit>
       <trans-unit id="40">
         <source>label.ticket.end_date</source>
         <target>Final date</target>
-        
+
       </trans-unit>
       <trans-unit id="41">
         <source>label.triage</source>
         <target>Screening</target>
-        
+
       </trans-unit>
       <trans-unit id="42">
         <source>label.ticket.user</source>
         <target>Operator</target>
-        
+
       </trans-unit>
       <trans-unit id="43">
         <source>label.status</source>
         <target>Status</target>
-        
+
       </trans-unit>
       <trans-unit id="44">
         <source>MM/DD/YYYY HH:mm:ss</source>
         <target>MM/DD/YYYY HH:mm:ss</target>
-        
+
       </trans-unit>
       <trans-unit id="45">
         <source>MM/DD/YYYY</source>
-        
+
       </trans-unit>
       <trans-unit id="49">
         <source>modal.search.button.submit</source>
         <target>Search</target>
-        
+
       </trans-unit>
       <trans-unit id="50">
         <source>server.datetime</source>
         <target>Date and time on server</target>
-        
+
       </trans-unit>
       <trans-unit id="51">
         <source>error.invalid_service</source>
         <target>Invalid service</target>
-        
+
       </trans-unit>
       <trans-unit id="52">
         <source>error.schedule.confirmed</source>
-        
-      </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        
+
       </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Name</target>
-        
+
       </trans-unit>
       <trans-unit id="55">
         <source>label.priority</source>
         <target>Priority</target>
-        
+
       </trans-unit>
       <trans-unit id="56">
         <source>label.ticket</source>
         <target>Ticket</target>
-        
+
       </trans-unit>
       <trans-unit id="57">
         <source>label.customer.id</source>
         <target>ID</target>
-        
+
       </trans-unit>
       <trans-unit id="58">
         <source>label.description</source>
         <target>Description</target>
-        
+
       </trans-unit>
       <trans-unit id="59">
         <source>label.subservices</source>
         <target>Subservices</target>
-        
+
       </trans-unit>
       <trans-unit id="60">
         <source>label.date</source>
         <target>Date</target>
-        
+
       </trans-unit>
       <trans-unit id="61">
         <source>label.time</source>

--- a/src/Resources/translations/NovosgaTriageBundle.es.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.es.xlf
@@ -14,239 +14,235 @@
       <trans-unit id="1">
         <source>title</source>
         <target>Selección</target>
-        
+
       </trans-unit>
       <trans-unit id="2">
         <source>subtitle</source>
         <target>Emisión de numero</target>
-        
+
       </trans-unit>
       <trans-unit id="3">
         <source>button.find</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="4">
         <source>placeholder.search</source>
         <target>Buscar Numero</target>
-        
+
       </trans-unit>
       <trans-unit id="5">
         <source>label.no_priority</source>
         <target>Normal</target>
-        
+
       </trans-unit>
       <trans-unit id="6">
         <source>label.priority</source>
         <target>Prioridad</target>
-        
+
       </trans-unit>
       <trans-unit id="7">
         <source>label.total</source>
         <target>Total</target>
-        
+
       </trans-unit>
       <trans-unit id="8">
         <source>modal.attendance</source>
         <target>Tratamiento</target>
-        
+
       </trans-unit>
       <trans-unit id="9">
         <source>modal.attendance.ticket</source>
         <target>Billete</target>
-        
+
       </trans-unit>
       <trans-unit id="10">
         <source>label.service</source>
         <target>Servicio</target>
-        
+
       </trans-unit>
       <trans-unit id="11">
         <source>label.ticket.wait_time</source>
         <target>Tiempo de espera</target>
-        
+
       </trans-unit>
       <trans-unit id="12">
         <source>label.customer</source>
         <target>Cliente</target>
-        
+
       </trans-unit>
       <trans-unit id="13">
         <source>label.customer.name</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="14">
         <source>label.customer.id</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="15">
         <source>label.yes</source>
         <target>Si</target>
-        
+
       </trans-unit>
       <trans-unit id="16">
         <source>label.no</source>
         <target>No</target>
-        
+
       </trans-unit>
       <trans-unit id="17">
         <source>alert.title</source>
         <target>Atención</target>
-        
+
       </trans-unit>
       <trans-unit id="18">
         <source>alert.cancel.text</source>
         <target>Desea realmente cancelar ese número?</target>
-        
+
       </trans-unit>
       <trans-unit id="19">
         <source>alert.reactivate.text</source>
         <target>Desea realmente reactivar ese número?</target>
-        
+
       </trans-unit>
       <trans-unit id="20">
         <source>alert.transfer.text</source>
         <target>¿Desea realmente transferir esta ese numero?</target>
-        
+
       </trans-unit>
       <trans-unit id="21">
         <source>modal.attendance.button.reactivate</source>
         <target>Reactivar número</target>
-        
+
       </trans-unit>
       <trans-unit id="22">
         <source>modal.attendance.button.transfer</source>
         <target>Transferir / Modificar número</target>
-        
+
       </trans-unit>
       <trans-unit id="23">
         <source>modal.attendance.button.cancel</source>
         <target>Cancelar número</target>
-        
+
       </trans-unit>
       <trans-unit id="24">
         <source>modal.transfer</source>
         <target>Transferir número</target>
-        
+
       </trans-unit>
       <trans-unit id="25">
         <source>modal.transfer.button</source>
         <target>Tranferir</target>
-        
+
       </trans-unit>
       <trans-unit id="35">
         <source>modal.search</source>
         <target>Busca</target>
-        
+
       </trans-unit>
       <trans-unit id="36">
         <source>modal.search.placeholder</source>
         <target>Contraseña completa, sigla o número</target>
-        
+
       </trans-unit>
       <trans-unit id="37">
         <source>label.ticket.number</source>
         <target>Número</target>
-        
+
       </trans-unit>
       <trans-unit id="38">
         <source>label.ticket.arrival_date</source>
         <target>Date de llegada</target>
-        
+
       </trans-unit>
       <trans-unit id="39">
         <source>label.ticket.start_date</source>
         <target>Data de inicio</target>
-        
+
       </trans-unit>
       <trans-unit id="40">
         <source>label.ticket.end_date</source>
         <target>Data de finalización</target>
-        
+
       </trans-unit>
       <trans-unit id="41">
         <source>label.triage</source>
         <target>Selección</target>
-        
+
       </trans-unit>
       <trans-unit id="42">
         <source>label.ticket.user</source>
         <target>Operador</target>
-        
+
       </trans-unit>
       <trans-unit id="43">
         <source>label.status</source>
         <target>Situación</target>
-        
+
       </trans-unit>
       <trans-unit id="44">
         <source>MM/DD/YYYY HH:mm:ss</source>
         <target>DD/MM/YYYY HH:mm:ss</target>
-        
+
       </trans-unit>
       <trans-unit id="45">
         <source>MM/DD/YYYY</source>
-        
+
       </trans-unit>
       <trans-unit id="49">
         <source>modal.search.button.submit</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="50">
         <source>server.datetime</source>
         <target>Fecha y hora en el servidor</target>
-        
+
       </trans-unit>
       <trans-unit id="51">
         <source>error.invalid_service</source>
         <target>Servicio inválido</target>
-        
+
       </trans-unit>
       <trans-unit id="52">
         <source>error.schedule.confirmed</source>
-        
-      </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        
+
       </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="55">
         <source>label.priority</source>
         <target>Prioridad</target>
-        
+
       </trans-unit>
       <trans-unit id="56">
         <source>label.ticket</source>
         <target>Contraseña</target>
-        
+
       </trans-unit>
       <trans-unit id="57">
         <source>label.customer.id</source>
         <target>Documento</target>
-        
+
       </trans-unit>
       <trans-unit id="58">
         <source>label.description</source>
         <target>Descripción</target>
-        
+
       </trans-unit>
       <trans-unit id="59">
         <source>label.subservices</source>
         <target>Subservicios</target>
-        
+
       </trans-unit>
       <trans-unit id="60">
         <source>label.date</source>
         <target>Dato</target>
-        
+
       </trans-unit>
       <trans-unit id="61">
         <source>label.time</source>

--- a/src/Resources/translations/NovosgaTriageBundle.es_AR.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.es_AR.xlf
@@ -14,242 +14,237 @@
       <trans-unit id="1">
         <source>title</source>
         <target>Selección</target>
-        
+
       </trans-unit>
       <trans-unit id="2">
         <source>subtitle</source>
         <target>Emisión de turnos</target>
-        
+
       </trans-unit>
       <trans-unit id="3">
         <source>button.find</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="4">
         <source>placeholder.search</source>
         <target>Buscar turno</target>
-        
+
       </trans-unit>
       <trans-unit id="5">
         <source>label.no_priority</source>
         <target>Normal</target>
-        
+
       </trans-unit>
       <trans-unit id="6">
         <source>label.priority</source>
         <target>Prioridad</target>
-        
+
       </trans-unit>
       <trans-unit id="7">
         <source>label.total</source>
         <target>Total</target>
-        
+
       </trans-unit>
       <trans-unit id="8">
         <source>modal.attendance</source>
         <target>Atención</target>
-        
+
       </trans-unit>
       <trans-unit id="9">
         <source>modal.attendance.ticket</source>
         <target>Turno</target>
-        
+
       </trans-unit>
       <trans-unit id="10">
         <source>label.service</source>
         <target>Servicio</target>
-        
+
       </trans-unit>
       <trans-unit id="11">
         <source>label.ticket.wait_time</source>
         <target>Tiempo de espera</target>
-        
+
       </trans-unit>
       <trans-unit id="12">
         <source>label.customer</source>
         <target>Cliente</target>
-        
+
       </trans-unit>
       <trans-unit id="13">
         <source>label.customer.name</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="14">
         <source>label.customer.id</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="15">
         <source>label.yes</source>
         <target>Sí</target>
-        
+
       </trans-unit>
       <trans-unit id="16">
         <source>label.no</source>
         <target>No</target>
-        
+
       </trans-unit>
       <trans-unit id="17">
         <source>alert.title</source>
         <target>Atención</target>
-        
+
       </trans-unit>
       <trans-unit id="18">
         <source>alert.cancel.text</source>
         <target>Desea realmente cancelar este turno?</target>
-        
+
       </trans-unit>
       <trans-unit id="19">
         <source>alert.reactivate.text</source>
         <target>Desea realmente reactivar este turno?</target>
-        
+
       </trans-unit>
       <trans-unit id="20">
         <source>alert.transfer.text</source>
         <target>Desea realmente transferir este turno?</target>
-        
+
       </trans-unit>
       <trans-unit id="21">
         <source>modal.attendance.button.reactivate</source>
         <target>Reactivar turno</target>
-        
+
       </trans-unit>
       <trans-unit id="22">
         <source>modal.attendance.button.transfer</source>
         <target>Transferir / Modificar turno</target>
-        
+
       </trans-unit>
       <trans-unit id="23">
         <source>modal.attendance.button.cancel</source>
         <target>Cancelar turno</target>
-        
+
       </trans-unit>
       <trans-unit id="24">
         <source>modal.transfer</source>
         <target>Transferir turno</target>
-        
+
       </trans-unit>
       <trans-unit id="25">
         <source>modal.transfer.button</source>
         <target>Transferir</target>
-        
+
       </trans-unit>
       <trans-unit id="35">
         <source>modal.search</source>
         <target>Busca</target>
-        
+
       </trans-unit>
       <trans-unit id="36">
         <source>modal.search.placeholder</source>
         <target>Turno completo, sigla o número</target>
-        
+
       </trans-unit>
       <trans-unit id="37">
         <source>label.ticket.number</source>
         <target>Número</target>
-        
+
       </trans-unit>
       <trans-unit id="38">
         <source>label.ticket.arrival_date</source>
         <target>Hora de ingreso</target>
-        
+
       </trans-unit>
       <trans-unit id="39">
         <source>label.ticket.start_date</source>
         <target>Hora de inicio</target>
-        
+
       </trans-unit>
       <trans-unit id="40">
         <source>label.ticket.end_date</source>
         <target>Hora de finalización</target>
-        
+
       </trans-unit>
       <trans-unit id="41">
         <source>label.triage</source>
         <target>Selección</target>
-        
+
       </trans-unit>
       <trans-unit id="42">
         <source>label.ticket.user</source>
         <target>Operador</target>
-        
+
       </trans-unit>
       <trans-unit id="43">
         <source>label.status</source>
         <target>Situación</target>
-        
+
       </trans-unit>
       <trans-unit id="44">
         <source>MM/DD/YYYY HH:mm:ss</source>
         <target>DD/MM/YYYY HH:mm:ss</target>
-        
+
       </trans-unit>
       <trans-unit id="45">
         <source>MM/DD/YYYY</source>
         <target>DD/MM/YYYY</target>
-        
+
       </trans-unit>
       <trans-unit id="49">
         <source>modal.search.button.submit</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="50">
         <source>server.datetime</source>
         <target>Fecha y hora en el servidor</target>
-        
+
       </trans-unit>
       <trans-unit id="51">
         <source>error.invalid_service</source>
         <target>Servicio inválido</target>
-        
+
       </trans-unit>
       <trans-unit id="52">
         <source>error.schedule.confirmed</source>
         <target>Turno ya confirmado</target>
-        
-      </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        <target>Turno expirado. Tiempo máximo de espera de 30 minutos.</target>
-        
+
       </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Nombre</target>
-        
+
       </trans-unit>
       <trans-unit id="55">
         <source>label.priority</source>
         <target>Prioridad</target>
-        
+
       </trans-unit>
       <trans-unit id="56">
         <source>label.ticket</source>
         <target>Turno</target>
-        
+
       </trans-unit>
       <trans-unit id="57">
         <source>label.customer.id</source>
         <target>Documento</target>
-        
+
       </trans-unit>
       <trans-unit id="58">
         <source>label.description</source>
         <target>Descripción</target>
-        
+
       </trans-unit>
       <trans-unit id="59">
         <source>label.subservices</source>
         <target>Subservicios</target>
-        
+
       </trans-unit>
       <trans-unit id="60">
         <source>label.date</source>
         <target>Datos</target>
-        
+
       </trans-unit>
       <trans-unit id="61">
         <source>label.time</source>

--- a/src/Resources/translations/NovosgaTriageBundle.pt_BR.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.pt_BR.xlf
@@ -170,10 +170,6 @@
         <source>error.schedule.confirmed</source>
         <target>Agendamento já confirmado</target>
       </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        <target>Agendamento expirado. Tempo máximo de espera de %min% minutos.</target>
-      </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Nome</target>

--- a/src/Resources/translations/NovosgaTriageBundle.pt_PT.xlf
+++ b/src/Resources/translations/NovosgaTriageBundle.pt_PT.xlf
@@ -14,231 +14,227 @@
       <trans-unit id="1">
         <source>title</source>
         <target>Triagem</target>
-        
+
       </trans-unit>
       <trans-unit id="2">
         <source>subtitle</source>
-        
+
       </trans-unit>
       <trans-unit id="3">
         <source>button.find</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="4">
         <source>placeholder.search</source>
-        
+
       </trans-unit>
       <trans-unit id="5">
         <source>label.no_priority</source>
         <target>Normal</target>
-        
+
       </trans-unit>
       <trans-unit id="6">
         <source>label.priority</source>
         <target>Prioridade</target>
-        
+
       </trans-unit>
       <trans-unit id="7">
         <source>label.total</source>
         <target>Total</target>
-        
+
       </trans-unit>
       <trans-unit id="8">
         <source>modal.attendance</source>
         <target>Atendimento</target>
-        
+
       </trans-unit>
       <trans-unit id="9">
         <source>modal.attendance.ticket</source>
         <target>Senha</target>
-        
+
       </trans-unit>
       <trans-unit id="10">
         <source>label.service</source>
         <target>Serviço</target>
-        
+
       </trans-unit>
       <trans-unit id="11">
         <source>label.ticket.wait_time</source>
         <target>Tempo de espera</target>
-        
+
       </trans-unit>
       <trans-unit id="12">
         <source>label.customer</source>
         <target>Cliente</target>
-        
+
       </trans-unit>
       <trans-unit id="13">
         <source>label.customer.name</source>
         <target>Nome</target>
-        
+
       </trans-unit>
       <trans-unit id="14">
         <source>label.customer.id</source>
         <target>Nome</target>
-        
+
       </trans-unit>
       <trans-unit id="15">
         <source>label.yes</source>
-        
+
       </trans-unit>
       <trans-unit id="16">
         <source>label.no</source>
-        
+
       </trans-unit>
       <trans-unit id="17">
         <source>alert.title</source>
         <target>Atenção</target>
-        
+
       </trans-unit>
       <trans-unit id="18">
         <source>alert.cancel.text</source>
         <target>Deseja realmente cancelar essa senha?</target>
-        
+
       </trans-unit>
       <trans-unit id="19">
         <source>alert.reactivate.text</source>
         <target>Deseja realmente reativar essa senha?</target>
-        
+
       </trans-unit>
       <trans-unit id="20">
         <source>alert.transfer.text</source>
-        
+
       </trans-unit>
       <trans-unit id="21">
         <source>modal.attendance.button.reactivate</source>
         <target>Reativar senha</target>
-        
+
       </trans-unit>
       <trans-unit id="22">
         <source>modal.attendance.button.transfer</source>
         <target>Transferir / Alterar senha</target>
-        
+
       </trans-unit>
       <trans-unit id="23">
         <source>modal.attendance.button.cancel</source>
         <target>Cancelar senha</target>
-        
+
       </trans-unit>
       <trans-unit id="24">
         <source>modal.transfer</source>
         <target>Tranferir Senha</target>
-        
+
       </trans-unit>
       <trans-unit id="25">
         <source>modal.transfer.button</source>
-        
+
       </trans-unit>
       <trans-unit id="35">
         <source>modal.search</source>
         <target>Pesquisa</target>
-        
+
       </trans-unit>
       <trans-unit id="36">
         <source>modal.search.placeholder</source>
-        
+
       </trans-unit>
       <trans-unit id="37">
         <source>label.ticket.number</source>
         <target>Número</target>
-        
+
       </trans-unit>
       <trans-unit id="38">
         <source>label.ticket.arrival_date</source>
         <target>Data chegada</target>
-        
+
       </trans-unit>
       <trans-unit id="39">
         <source>label.ticket.start_date</source>
         <target>Data início</target>
-        
+
       </trans-unit>
       <trans-unit id="40">
         <source>label.ticket.end_date</source>
         <target>Data fim</target>
-        
+
       </trans-unit>
       <trans-unit id="41">
         <source>label.triage</source>
         <target>Triagem</target>
-        
+
       </trans-unit>
       <trans-unit id="42">
         <source>label.ticket.user</source>
         <target>Atendente</target>
-        
+
       </trans-unit>
       <trans-unit id="43">
         <source>label.status</source>
         <target>Situação</target>
-        
+
       </trans-unit>
       <trans-unit id="44">
         <source>MM/DD/YYYY HH:mm:ss</source>
-        
+
       </trans-unit>
       <trans-unit id="45">
         <source>MM/DD/YYYY</source>
-        
+
       </trans-unit>
       <trans-unit id="49">
         <source>modal.search.button.submit</source>
         <target>Consultar</target>
-        
+
       </trans-unit>
       <trans-unit id="50">
         <source>server.datetime</source>
         <target>Data e hora no servidor</target>
-        
+
       </trans-unit>
       <trans-unit id="51">
         <source>error.invalid_service</source>
         <target>Serviço inválido</target>
-        
+
       </trans-unit>
       <trans-unit id="52">
         <source>error.schedule.confirmed</source>
-        
-      </trans-unit>
-      <trans-unit id="53">
-        <source>error.schedule.expired</source>
-        
+
       </trans-unit>
       <trans-unit id="54">
         <source>label.name</source>
         <target>Nome</target>
-        
+
       </trans-unit>
       <trans-unit id="55">
         <source>label.priority</source>
         <target>Prioridade</target>
-        
+
       </trans-unit>
       <trans-unit id="56">
         <source>label.ticket</source>
         <target>Senha</target>
-        
+
       </trans-unit>
       <trans-unit id="57">
         <source>label.customer.id</source>
         <target>Documento</target>
-        
+
       </trans-unit>
       <trans-unit id="58">
         <source>label.description</source>
         <target>Descrição</target>
-        
+
       </trans-unit>
       <trans-unit id="59">
         <source>label.subservices</source>
         <target>Sub-serviços</target>
-        
+
       </trans-unit>
       <trans-unit id="60">
         <source>label.date</source>
         <target>Data</target>
-        
+
       </trans-unit>
       <trans-unit id="61">
         <source>label.time</source>


### PR DESCRIPTION
Issue: https://github.com/novosga/novosga/issues/479

This pull request removes the logic that enforced a maximum allowed delay for scheduling appointments and also removes the related expired schedule error message from all translation files. The main effect is that the system no longer checks or blocks the distribution of expired scheduled appointments based on a time limit.

Key changes:

**Removal of scheduling delay logic:**
* Deleted the check in `DefaultController.php` that enforced a maximum allowed delay (`MAX_SCHEDULING_MINUTES_DELAY`) for distributing scheduled appointments, along with the related constant and dependency on `ClockInterface`. [[1]](diffhunk://#diff-400ac651f8557c655affcb5e47882541c382f96fd88e51334dc66ebad66e1304L48-L49) [[2]](diffhunk://#diff-400ac651f8557c655affcb5e47882541c382f96fd88e51334dc66ebad66e1304L226) [[3]](diffhunk://#diff-400ac651f8557c655affcb5e47882541c382f96fd88e51334dc66ebad66e1304L237-L254)

**Translation cleanup:**
* Removed the `error.schedule.expired` translation key and its translations from all translation files: `NovosgaTriageBundle.en.xlf`, `NovosgaTriageBundle.en_US.xlf`, `NovosgaTriageBundle.es.xlf`, `NovosgaTriageBundle.es_AR.xlf`, `NovosgaTriageBundle.pt_BR.xlf`, and `NovosgaTriageBundle.pt_PT.xlf`. [[1]](diffhunk://#diff-39293dc61194da828d0ba0174c65c54ea4a5cc51eba91b94713adbbf55adae4bL211-L214) [[2]](diffhunk://#diff-d0b1cc9c69e2e08a56683780e940970e0c7c9ac47473fc16dd2d1031b72bfdd2L211-L214) [[3]](diffhunk://#diff-591cdab4f863c2ca8dd1d22a584f78d06f6340dc00b83cd8b711776bcf33276cL211-L214) [[4]](diffhunk://#diff-9e237663564be5e049ee5eb958070acb2a82c91f98642f97dd5b30cd51840ea7L213-L217) [[5]](diffhunk://#diff-990ff97992c216f060cfd63b77bbcd2571e026b8ebcba26fe64dff34b3c32c6cL173-L176) [[6]](diffhunk://#diff-943e375294cbdb7f3324f90f21d99a1802fb3fc01940fd81f07613749e7bd6e7L203-L206)